### PR TITLE
Added a check to the call functions if there are no loaded extension to allow the use of the default functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ temp/
 
 # Tesseract-OCR
 Tesseract-OCR/*
-!Tesseract-OCR/tessdata
+Tesseract-OCR/tessdata

--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ def call_get_basic_label_icons(character_spec: dict, grabbable_spec: dict) -> li
                     icons.extend(result)
         if extension_load_mode == LOAD_MODE_OVERRIDE:
             return icons
-    if extension_load_mode == LOAD_MODE_BEFORE or extension_load_mode == "":
+    if extension_load_mode == LOAD_MODE_BEFORE or extension_load_mode == "" or len(loaded_extensions) == 0: #also check if loaded_extensions is empty
         icons.extend(get_basic_label_icons(character_spec, grabbable_spec))
     return icons
 
@@ -241,7 +241,7 @@ def call_get_advanced_label_text(character_spec: dict, grabbable_spec: dict) -> 
                 if isinstance(result, str):
                     text += result
         return text
-    if extension_load_mode == LOAD_MODE_BEFORE or extension_load_mode == "":
+    if extension_load_mode == LOAD_MODE_BEFORE or extension_load_mode == "" or len(loaded_extensions) == 0: #also check if loaded_extensions is empty
         text += get_advanced_label_text(character_spec, grabbable_spec)
     return text
 


### PR DESCRIPTION
Testing the code myself, I found when saving the template given for the extensions, it was loading the template right after as "mode: override" with no extensions given so when trying to call them, nothing was happening.